### PR TITLE
Fix plugin service binding

### DIFF
--- a/Orion/Framework/OrionModule.cs
+++ b/Orion/Framework/OrionModule.cs
@@ -85,6 +85,7 @@ namespace Orion.Framework
 			foreach (Type sharedModule in GetSubclasses<SharedService>().Concat(GetSubclasses<Plugin>()))
 			{
 				Bind(sharedModule).ToSelf().InSingletonScope();
+				Bind(sharedModule.BaseType).To(sharedModule).InSingletonScope();
 				foreach (Type sharedModuleInterface in GetInterfaces(sharedModule))
 				{
 					Bind(sharedModuleInterface).To(sharedModule).InSingletonScope();


### PR DESCRIPTION
This fixes binding with `Plugin` and `SharedService`.
Previously, nothing will be bounden for plugins since they don't implement any interface. As a result, no plugins will be properly loaded on startup process from Orion.cs:
```csharp
foreach (Plugin plugin in _injectionContainer.GetAll<Plugin>())
```

Not sure if this is the proper way to fix this problem; need to be reviewed.